### PR TITLE
Ship universal VSIX without bundled CLI binary

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,38 +10,13 @@ permissions:
 
 jobs:
   build-vsix:
-    strategy:
-      matrix:
-        include:
-          - rid: osx-arm64
-            target: darwin-arm64
-          - rid: osx-x64
-            target: darwin-x64
-          - rid: linux-x64
-            target: linux-x64
-          - rid: win-x64
-            target: win32-x64
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
 
-      - uses: actions/setup-dotnet@v4
-        with:
-          dotnet-version: "10.0.x"
-
       - uses: actions/setup-node@v4
         with:
           node-version: 22
-
-      - name: Build CLI (${{ matrix.rid }})
-        run: |
-          dotnet publish src/Nap.Cli/Nap.Cli.fsproj \
-            -r ${{ matrix.rid }} \
-            --self-contained \
-            -p:PublishTrimmed=true \
-            -p:PublishSingleFile=true \
-            -o src/Nap.VsCode/bin \
-            --nologo
 
       - name: Install extension dependencies
         working-directory: src/Nap.VsCode
@@ -51,14 +26,14 @@ jobs:
         working-directory: src/Nap.VsCode
         run: npx webpack --mode production
 
-      - name: Package VSIX (${{ matrix.target }})
+      - name: Package universal VSIX
         working-directory: src/Nap.VsCode
-        run: npx @vscode/vsce package --target ${{ matrix.target }} --no-dependencies --skip-license
+        run: npx @vscode/vsce package --no-dependencies --skip-license
 
       - name: Upload VSIX
         uses: actions/upload-artifact@v4
         with:
-          name: vsix-${{ matrix.target }}
+          name: vsix
           path: src/Nap.VsCode/*.vsix
 
   build-cli:

--- a/src/Nap.VsCode/.vscodeignore
+++ b/src/Nap.VsCode/.vscodeignore
@@ -7,4 +7,4 @@ webpack.config.js
 **/*.map
 **/*.pdb
 !dist/**
-!bin/**
+bin/**


### PR DESCRIPTION
# TLDR;

Simplify the release pipeline to produce a single universal VSIX that no longer bundles the platform-specific CLI binary.

# Details

- Remove the platform matrix (osx-arm64, osx-x64, linux-x64, win-x64) from the `build-vsix` job — now builds one universal VSIX
- Remove the .NET SDK setup and `dotnet publish` step from VSIX packaging
- Exclude the `bin/` directory from the VSIX via `.vscodeignore`
- The separate `build-cli` job is unaffected and continues to produce platform-specific CLI artifacts

# How do the tests prove the change works

Pipeline change — verified by successful CI build and VSIX packaging on push.