### PR TITLE
Release: NuGet keyless OIDC + Marketplace via org VSCODE_MARKETPLACE_PAT (sibling pattern)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -390,43 +390,26 @@ jobs:
     if: ${{ !cancelled() && needs.package-vsix.result != 'skipped' }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    # KEYLESS publish — OIDC + Microsoft Entra workload-identity federation, NO VSCE_PAT.
-    # azure/login exchanges a short-lived GitHub OIDC token for an Entra access token
-    # (federated credential, ZERO client secret); `vsce --azure-credential` then
-    # publishes using that ambient Azure session. A long-lived Marketplace PAT is
-    # forbidden. Implements [SWR-SEC-OIDC-PUBLISH], [SWR-SEC-NO-PAT].
+    # Per-platform Marketplace publish via the Nimblesite ORG-level VSCODE_MARKETPLACE_PAT
+    # secret — the SAME pattern Basilisk and too-many-cooks use. napper must be on that org
+    # secret's repository allowlist. (NuGet/npm use OIDC; the VS Code Marketplace does not —
+    # the org standard is a scoped Marketplace PAT.) Implements [SWR-VSIX-PUBLISH].
     permissions:
-      id-token: write # mint the GitHub OIDC token for the Entra exchange
       contents: read # least privilege: drop the inherited contents: write
     steps:
-      # Turn a missing OIDC config into an actionable operator error before login runs.
-      # AZURE_CLIENT_ID / AZURE_TENANT_ID are NOT credentials (no secret/PAT) — the
-      # trust lives in the Entra federated credential, so they are repo variables. The
-      # GitHub Release + Homebrew + Scoop do NOT depend on this job, so a missing config
+      # Turn a missing/forbidden org secret into an actionable operator error. The GitHub
+      # Release + Open VSX + Homebrew + Scoop do NOT depend on this job, so a missing token
       # never blocks the native-binary release — only the Marketplace publish waits.
-      - name: Require Marketplace OIDC config
+      - name: Require Marketplace credential
         env:
-          AZURE_CLIENT_ID: ${{ vars.AZURE_CLIENT_ID }}
-          AZURE_TENANT_ID: ${{ vars.AZURE_TENANT_ID }}
+          VSCE_PAT: ${{ secrets.VSCODE_MARKETPLACE_PAT }}
         run: |
           set -euo pipefail
-          missing=""
-          [ -z "${AZURE_CLIENT_ID:-}" ] && missing="$missing AZURE_CLIENT_ID"
-          [ -z "${AZURE_TENANT_ID:-}" ] && missing="$missing AZURE_TENANT_ID"
-          if [ -n "$missing" ]; then
-            echo "::error title=Marketplace OIDC variables not set::Set the repo VARIABLES$missing. Create a Microsoft Entra app (or user-assigned managed identity) with a federated credential trusting this repo's GitHub OIDC, add it as a Marketplace publisher member (Contributor), then set AZURE_CLIENT_ID and AZURE_TENANT_ID. Publishing is keyless — NO PAT is used. The GitHub Release (with all VSIX + CLI assets), Homebrew, and Scoop already shipped independently. Guide: https://code.visualstudio.com/api/working-with-extensions/publishing-extension"
+          if [ -z "${VSCE_PAT:-}" ]; then
+            echo "::error title=VSCODE_MARKETPLACE_PAT not accessible::Add a VS Code Marketplace PAT (Marketplace → Manage scope) as the Nimblesite ORG secret VSCODE_MARKETPLACE_PAT and add this repository to its allowed list (Org Settings → Secrets and variables → Actions → VSCODE_MARKETPLACE_PAT → Repository access). The GitHub Release (with all VSIX + CLI assets), Open VSX, Homebrew, and Scoop ship independently. Token guide: https://code.visualstudio.com/api/working-with-extensions/publishing-extension#get-a-personal-access-token"
             exit 1
           fi
-          echo "Marketplace OIDC config present — proceeding with federated login."
-      # Federated login: no client secret, no PAT. With id-token: write granted and no
-      # `creds` supplied, azure/login performs the OIDC token exchange and leaves an
-      # authenticated Azure CLI session that `vsce --azure-credential` consumes.
-      - name: Azure login (OIDC federated, secretless)
-        uses: azure/login@v2
-        with:
-          client-id: ${{ vars.AZURE_CLIENT_ID }}
-          tenant-id: ${{ vars.AZURE_TENANT_ID }}
-          allow-no-subscriptions: true
+          echo "VSCODE_MARKETPLACE_PAT present — proceeding with Marketplace publish."
       - uses: actions/setup-node@v6
         with:
           node-version: 22
@@ -444,14 +427,15 @@ jobs:
           merge-multiple: true
       # One `vsce publish` per platform VSIX: vsce silently uses only the FIRST when several
       # are passed in a single call (the previous single-call step published only one
-      # platform). Each --target VSIX MUST be published on its own. Auth is keyless via
-      # --azure-credential (the azure/login OIDC session). The publish is IDEMPOTENT — a
-      # target whose (version, platform) is already on the Marketplace ("already exists")
-      # counts as success, so a re-run after a partial publish completes the remaining
-      # platforms instead of aborting on the first duplicate. Transient errors retry up to
-      # 3x; one failed platform never blocks the others.
-      # Salvaged from repo-standardization@319159f. Implements [SWR-VSIX-PUBLISH], [SWR-SEC-OIDC-PUBLISH].
+      # platform). Each --target VSIX MUST be published on its own. The publish is
+      # IDEMPOTENT — a target whose (version, platform) is already on the Marketplace
+      # ("already exists") counts as success, so a re-run after a partial publish completes
+      # the remaining platforms instead of aborting on the first duplicate. Transient errors
+      # retry up to 3x; one failed platform never blocks the others.
+      # Salvaged from repo-standardization@319159f. Implements [SWR-VSIX-PUBLISH].
       - name: Publish each platform VSIX
+        env:
+          VSCE_PAT: ${{ secrets.VSCODE_MARKETPLACE_PAT }}
         run: |
           set -uo pipefail
           shopt -s globstar nullglob
@@ -463,7 +447,7 @@ jobs:
           publish_one() {
             local vsix="$1" attempt out rc
             for attempt in 1 2 3; do
-              out="$(vsce publish ${flag} --azure-credential --packagePath "${vsix}" 2>&1)"; rc=$?
+              out="$(vsce publish ${flag} --packagePath "${vsix}" 2>&1)"; rc=$?
               echo "${out}"
               if [ "${rc}" -eq 0 ]; then return 0; fi
               if echo "${out}" | grep -qiE "already exists"; then
@@ -573,6 +557,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     continue-on-error: true
+    # Protected environment so GitHub injects the `environment` claim into the OIDC token.
+    # The nuget.org trusted-publishing policy is scoped to Environment=release, and the
+    # token only carries that claim when the job is bound to the environment. MUST match.
+    environment: release
     # KEYLESS publish — OIDC Trusted Publishing, NO long-lived NuGet API key.
     # The job exchanges a short-lived GitHub OIDC token for a ~1h nuget.org API key
     # via a trusted-publishing policy (owner + repository + this workflow file). This

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -390,21 +390,43 @@ jobs:
     if: ${{ !cancelled() && needs.package-vsix.result != 'skipped' }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    # KEYLESS publish — OIDC + Microsoft Entra workload-identity federation, NO VSCE_PAT.
+    # azure/login exchanges a short-lived GitHub OIDC token for an Entra access token
+    # (federated credential, ZERO client secret); `vsce --azure-credential` then
+    # publishes using that ambient Azure session. A long-lived Marketplace PAT is
+    # forbidden. Implements [SWR-SEC-OIDC-PUBLISH], [SWR-SEC-NO-PAT].
+    permissions:
+      id-token: write # mint the GitHub OIDC token for the Entra exchange
+      contents: read # least privilege: drop the inherited contents: write
     steps:
-      # Turn the Marketplace's opaque "TF400813: user aaaaaaaa-... not authorized" (what
-      # you get from an empty/blank PAT) into an actionable, operator-facing error. The
-      # GitHub Release + Homebrew + Scoop do NOT depend on this job, so a missing token
+      # Turn a missing OIDC config into an actionable operator error before login runs.
+      # AZURE_CLIENT_ID / AZURE_TENANT_ID are NOT credentials (no secret/PAT) — the
+      # trust lives in the Entra federated credential, so they are repo variables. The
+      # GitHub Release + Homebrew + Scoop do NOT depend on this job, so a missing config
       # never blocks the native-binary release — only the Marketplace publish waits.
-      - name: Require Marketplace credential
+      - name: Require Marketplace OIDC config
         env:
-          VSCE_PAT: ${{ secrets.VSCE_PAT }}
+          AZURE_CLIENT_ID: ${{ vars.AZURE_CLIENT_ID }}
+          AZURE_TENANT_ID: ${{ vars.AZURE_TENANT_ID }}
         run: |
           set -euo pipefail
-          if [ -z "${VSCE_PAT:-}" ]; then
-            echo "::error title=VSCE_PAT secret is not set::Add a VS Code Marketplace Personal Access Token as the repo secret VSCE_PAT, then re-run, to publish the per-platform VSIXs. The GitHub Release (with all VSIX + CLI assets), Homebrew, and Scoop already shipped independently. Token guide: https://code.visualstudio.com/api/working-with-extensions/publishing-extension#get-a-personal-access-token"
+          missing=""
+          [ -z "${AZURE_CLIENT_ID:-}" ] && missing="$missing AZURE_CLIENT_ID"
+          [ -z "${AZURE_TENANT_ID:-}" ] && missing="$missing AZURE_TENANT_ID"
+          if [ -n "$missing" ]; then
+            echo "::error title=Marketplace OIDC variables not set::Set the repo VARIABLES$missing. Create a Microsoft Entra app (or user-assigned managed identity) with a federated credential trusting this repo's GitHub OIDC, add it as a Marketplace publisher member (Contributor), then set AZURE_CLIENT_ID and AZURE_TENANT_ID. Publishing is keyless — NO PAT is used. The GitHub Release (with all VSIX + CLI assets), Homebrew, and Scoop already shipped independently. Guide: https://code.visualstudio.com/api/working-with-extensions/publishing-extension"
             exit 1
           fi
-          echo "VSCE_PAT present — proceeding with Marketplace publish."
+          echo "Marketplace OIDC config present — proceeding with federated login."
+      # Federated login: no client secret, no PAT. With id-token: write granted and no
+      # `creds` supplied, azure/login performs the OIDC token exchange and leaves an
+      # authenticated Azure CLI session that `vsce --azure-credential` consumes.
+      - name: Azure login (OIDC federated, secretless)
+        uses: azure/login@v2
+        with:
+          client-id: ${{ vars.AZURE_CLIENT_ID }}
+          tenant-id: ${{ vars.AZURE_TENANT_ID }}
+          allow-no-subscriptions: true
       - uses: actions/setup-node@v6
         with:
           node-version: 22
@@ -422,15 +444,14 @@ jobs:
           merge-multiple: true
       # One `vsce publish` per platform VSIX: vsce silently uses only the FIRST when several
       # are passed in a single call (the previous single-call step published only one
-      # platform). Each --target VSIX MUST be published on its own. The publish is
-      # IDEMPOTENT — a target whose (version, platform) is already on the Marketplace
-      # ("already exists") counts as success, so a re-run after a partial publish completes
-      # the remaining platforms instead of aborting on the first duplicate. Transient errors
-      # retry up to 3x; one failed platform never blocks the others.
-      # Salvaged from repo-standardization@319159f. Implements [SWR-VSIX-PUBLISH].
+      # platform). Each --target VSIX MUST be published on its own. Auth is keyless via
+      # --azure-credential (the azure/login OIDC session). The publish is IDEMPOTENT — a
+      # target whose (version, platform) is already on the Marketplace ("already exists")
+      # counts as success, so a re-run after a partial publish completes the remaining
+      # platforms instead of aborting on the first duplicate. Transient errors retry up to
+      # 3x; one failed platform never blocks the others.
+      # Salvaged from repo-standardization@319159f. Implements [SWR-VSIX-PUBLISH], [SWR-SEC-OIDC-PUBLISH].
       - name: Publish each platform VSIX
-        env:
-          VSCE_PAT: ${{ secrets.VSCE_PAT }}
         run: |
           set -uo pipefail
           shopt -s globstar nullglob
@@ -442,7 +463,7 @@ jobs:
           publish_one() {
             local vsix="$1" attempt out rc
             for attempt in 1 2 3; do
-              out="$(vsce publish ${flag} --packagePath "${vsix}" 2>&1)"; rc=$?
+              out="$(vsce publish ${flag} --azure-credential --packagePath "${vsix}" 2>&1)"; rc=$?
               echo "${out}"
               if [ "${rc}" -eq 0 ]; then return 0; fi
               if echo "${out}" | grep -qiE "already exists"; then
@@ -552,9 +573,30 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     continue-on-error: true
+    # KEYLESS publish — OIDC Trusted Publishing, NO long-lived NuGet API key.
+    # The job exchanges a short-lived GitHub OIDC token for a ~1h nuget.org API key
+    # via a trusted-publishing policy (owner + repository + this workflow file). This
+    # is MANDATORY: a static API-key secret for a package registry is forbidden.
+    # Implements [SWR-SEC-OIDC-PUBLISH], [SWR-SEC-NO-PAT].
+    permissions:
+      id-token: write # mint the GitHub OIDC token for the nuget.org exchange
+      contents: read # least privilege: drop the inherited contents: write
     env:
       VERSION: ${{ needs.validate-tag.outputs.version }}
     steps:
+      # Turn a missing trusted-publishing config into an actionable operator error
+      # before any pack/push runs. NUGET_USER is the nuget.org account name, NOT a
+      # credential — it is a repo variable, not a secret.
+      - name: Require NuGet trusted-publishing config
+        env:
+          NUGET_USER: ${{ vars.NUGET_USER }}
+        run: |
+          set -euo pipefail
+          if [ -z "${NUGET_USER:-}" ]; then
+            echo "::error title=NUGET_USER variable is not set::Set the repo VARIABLE NUGET_USER to your nuget.org account/profile name (NOT email), and create a Trusted Publishing policy on nuget.org (owner + repository 'napper' + workflow file 'release.yml'). Publishing is keyless via OIDC — NO API-key secret is used. Guide: https://learn.microsoft.com/nuget/nuget-org/trusted-publishing"
+            exit 1
+          fi
+          echo "NUGET_USER present — proceeding with OIDC trusted publishing."
       - uses: actions/checkout@v6
       - uses: actions/setup-dotnet@v5
         with:
@@ -568,10 +610,18 @@ jobs:
           bash scripts/generate-types.sh
       - name: Pack dotnet tool (version from tag)
         run: dotnet pack src/Napper.Cli/Napper.Cli.fsproj -c Release -p:Version="$VERSION" --nologo
+      # Exchange the GitHub OIDC token for a short-lived (~1h) nuget.org API key.
+      # Minted immediately before the push so it cannot expire in transit; the key is
+      # single-use and never stored. Implements [SWR-SEC-OIDC-PUBLISH].
+      - name: NuGet login (OIDC → short-lived API key)
+        uses: NuGet/login@v1
+        id: nuget_login
+        with:
+          user: ${{ vars.NUGET_USER }}
       - name: Push to NuGet (skip if already published)
         run: |
           dotnet nuget push "src/Napper.Cli/nupkg/napper.${VERSION}.nupkg" \
-            --api-key "${{ secrets.NIMBLESITE_NUGET_KEY }}" \
+            --api-key "${{ steps.nuget_login.outputs.NUGET_API_KEY }}" \
             --source https://api.nuget.org/v3/index.json \
             --skip-duplicate
 


### PR DESCRIPTION
## TLDR
Fix the `v0.13.0` release failures: **NuGet → keyless OIDC trusted publishing**, **VS Code Marketplace → the Nimblesite org `VSCODE_MARKETPLACE_PAT` pattern** used by Basilisk / too-many-cooks. The original failure was the wrong Marketplace secret name (`VSCE_PAT`) + a missing NuGet API key.

## What changed in `release.yml`
- **`publish-nuget`** — keyless OIDC via `NuGet/login@v1` (short-lived ~1h key from a trusted-publishing policy); dropped `NIMBLESITE_NUGET_KEY`. Added `permissions: id-token: write` + `contents: read`, and **`environment: release`** so the OIDC token carries the environment claim the nuget.org policy is scoped to.
- **`publish-marketplace`** — matches the sibling repos: publishes each per-platform VSIX with `VSCE_PAT` sourced from the **org secret `secrets.VSCODE_MARKETPLACE_PAT`** (repo must be on its allowlist). Narrowed to `permissions: contents: read`. Kept the per-platform retry + idempotent `already exists` handling.
- **Open VSX / Homebrew / Scoop** — unchanged (`OPEN_VSX_PAT`, `BREW_SCOOP_PAT`), matching the siblings.

## Operator setup required
- **NuGet (done):** trusted-publishing policy — Repository Owner `Nimblesite`, **Repository `napper`** (not `Nimblesite`), Workflow `release.yml`, **Environment `release`**. Repo variable `NUGET_USER` = nuget.org account name.
- **Marketplace:** org secret `VSCODE_MARKETPLACE_PAT` (Marketplace → Manage scope) with **napper added to its repository allowlist** (Org → Settings → Secrets and variables → Actions).
- **Open VSX / brew / scoop:** `OPEN_VSX_PAT`, `BREW_SCOOP_PAT` present + napper on their allowlists.

## Breaking changes
Operational only: releases publish to NuGet/Marketplace once the policy + org-secret allowlist + `NUGET_USER` are in place. No code/runtime impact.

Implements `[SWR-VSIX-PUBLISH]`, `[SWR-SEC-OIDC-PUBLISH]`.
