### PR TITLE
NuGet: publish as Nimblesite.Napper (bare 'napper' id is owned by another project)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -601,8 +601,10 @@ jobs:
         with:
           user: ${{ env.NUGET_USER }}
       - name: Push to NuGet (skip if already published)
+        # Glob the single packed .nupkg so the push is decoupled from the PackageId
+        # (currently Nimblesite.Napper.<version>.nupkg, not napper.<version>.nupkg).
         run: |
-          dotnet nuget push "src/Napper.Cli/nupkg/napper.${VERSION}.nupkg" \
+          dotnet nuget push src/Napper.Cli/nupkg/*.nupkg \
             --api-key "${{ steps.nuget_login.outputs.NUGET_API_KEY }}" \
             --source https://api.nuget.org/v3/index.json \
             --skip-duplicate

--- a/src/Napper.Cli/Napper.Cli.fsproj
+++ b/src/Napper.Cli/Napper.Cli.fsproj
@@ -17,7 +17,12 @@
          the NuGet publish job is non-blocking and never gates the release. -->
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>napper</ToolCommandName>
-    <PackageId>napper</PackageId>
+    <!-- The bare `napper` id is owned on nuget.org by an unrelated "Napper ORM Project",
+         so we publish under the org-prefixed id (matches Nimblesite's existing
+         Nimblesite.* packages and is pushable by the Nimblesite trusted-publishing
+         policy). ToolCommandName stays `napper`: `dotnet tool install -g Nimblesite.Napper`
+         still installs a `napper` command. -->
+    <PackageId>Nimblesite.Napper</PackageId>
     <PackageOutputPath>./nupkg</PackageOutputPath>
     <PackageTags>http;api;testing;cli;rest;fsharp;dotnet-tool</PackageTags>
 


### PR DESCRIPTION
v0.13.4 confirmed OIDC works with `NUGET_USER=Nimblesite` (login succeeded). The push 403'd because **`napper` on nuget.org is owned by the unrelated "Napper ORM Project"** (v1.0.0, unlisted). Switch `PackageId` to **`Nimblesite.Napper`** (available; matches the org's `Nimblesite.*` packages; pushable by the trusted-publishing policy). `ToolCommandName` stays `napper`. All other channels green since v0.13.1.